### PR TITLE
Switch to Release Build

### DIFF
--- a/lib/system.js
+++ b/lib/system.js
@@ -17,7 +17,7 @@ const allOS = {
 	},
 	darwin: {
 		x64: {
-			url: 'https://ffmpeg.zeranoe.com/builds/macos64/static/ffmpeg-latest-macos64-static.zip',
+			url: 'https://ffmpeg.zeranoe.com/builds/macos64/static/ffmpeg-4.2.2-macos64-static.zip',
 			path: rootDir + '/ffmpeg/darwinx64/bin/ffmpeg'
 		}
 	},


### PR DESCRIPTION
Originally, latest would fetch the nightly build. As of right now, there seems to be an issue with the nightly builds, so instead use the current latest release build.